### PR TITLE
Add link to imgclsmob repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Just a few keras-things I found useful.
 5. https://github.com/titu1994/DenseNet
 6. [BatchRenormalization: Batch Renormalization algorithm implementation in Keras](https://github.com/titu1994/BatchRenormalization)
 7. [mlp: Multilayer Perceptron Keras wrapper for sklearn](https://github.com/alvarouc/mlp)
+8. [Image-Classification-Mobile: Collection of pretrained classification models for Keras with MXNet backend](https://github.com/osmr/imgclsmob)
 
 ## Visualization Tools
 


### PR DESCRIPTION
Please, add a link to the `imgclsmob` repo with a collection of classification models for Keras with MXNet backend.